### PR TITLE
Commonmark upgrade - RSC-497

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "staticpath": "demo/dist"
   },
   "dependencies": {
-    "commonmark": "^0.27.0",
+    "commonmark": "^0.29.1",
     "commonmark-react-renderer": "^4.3.3",
     "in-publish": "^2.0.0",
     "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "json-loader": "^0.5.4",
     "lodash.assign": "^4.0.9",
     "mocha": "^3.4.2",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "~1.1.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "standard": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "commonmark": "^0.29.1",
-    "commonmark-react-renderer": "^4.3.3",
+    "@sonatype/commonmark-react-renderer": "^4.3.6",
     "in-publish": "^2.0.0",
     "prop-types": "^15.5.10"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "json-loader": "^0.5.4",
     "lodash.assign": "^4.0.9",
     "mocha": "^3.4.2",
-    "mocha-jsdom": "~1.1.0",
+    "mocha-jsdom": "^1.1.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "standard": "^10.0.2",

--- a/src/react-commonmark.js
+++ b/src/react-commonmark.js
@@ -2,7 +2,7 @@
 
 var React = require('react')
 var Parser = require('commonmark').Parser
-var ReactRenderer = require('commonmark-react-renderer')
+var ReactRenderer = require('@sonatype/commonmark-react-renderer')
 var propTypes = require('prop-types')
 
 function ReactCommonmark (props) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,13 +552,14 @@ commonmark-react-renderer@^4.3.3:
     pascalcase "^0.1.1"
     xss-filters "^1.2.6"
 
-commonmark@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.27.0.tgz#d86c262b962821e9483c69c547bc58840c047b34"
+commonmark@^0.29.1:
+  version "0.29.3"
+  resolved "https://repo.sonatype.com/repository/npm-all/commonmark/-/commonmark-0.29.3.tgz#bb1d5733bfe3ea213b412f33f16439cc12999c2c"
+  integrity sha512-fvt/NdOFKaL2gyhltSy6BC4LxbbxbnPxBMl923ittqO/JBM0wQHaoYZliE4tp26cRxX/ZZtRsJlZzQrVdUkXAA==
   dependencies:
-    entities "~ 1.1.1"
-    mdurl "~ 1.0.1"
-    minimist "~ 1.2.0"
+    entities "~2.0"
+    mdurl "~1.0.1"
+    minimist ">=1.2.2"
     string.prototype.repeat "^0.2.0"
 
 concat-map@0.0.1:
@@ -880,9 +881,10 @@ enhanced-resolve@^3.0.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
-"entities@~ 1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+entities@~2.0:
+  version "2.0.3"
+  resolved "https://repo.sonatype.com/repository/npm-all/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 errno@^0.1.3:
   version "0.1.4"
@@ -2043,9 +2045,10 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
-"mdurl@~ 1.0.1":
+mdurl@~1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  resolved "https://repo.sonatype.com/repository/npm-all/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -2107,11 +2110,16 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
+minimist@>=1.2.2:
+  version "1.2.5"
+  resolved "https://repo.sonatype.com/repository/npm-all/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.0.tgz#4dffe525dae2b864c66c2e23c6271d7afdecefce"
 
-minimist@^1.1.0, minimist@^1.2.0, "minimist@~ 1.2.0":
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@sonatype/commonmark-react-renderer@^4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@sonatype/commonmark-react-renderer/-/commonmark-react-renderer-4.3.6.tgz#c08e3a812850bcb5e31b321e6f6a7bfb0ab31028"
+  integrity sha512-MA6p6SR9nOCdELtYLOGWBNMHyQOJitIHuu024w77rPAhhV7Ut7//vseoDrypyeHJJf0qJ6wGSc67TC7xkmplsg==
+  dependencies:
+    lodash.assign "^4.2.0"
+    lodash.isplainobject "^4.0.6"
+    pascalcase "^0.1.1"
+    xss-filters "^1.2.6"
+
 "@types/react@^15.0.31":
   version "15.0.31"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.31.tgz#21dfc5d41ee1600ff7d7b738ad21a9502aa3ecf2"
@@ -541,16 +551,6 @@ commander@2.9.0, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commonmark-react-renderer@^4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/commonmark-react-renderer/-/commonmark-react-renderer-4.3.3.tgz#9c4bca138bc83287bae792ccf133738be9cbc6fa"
-  dependencies:
-    in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.isplainobject "^4.0.6"
-    pascalcase "^0.1.1"
-    xss-filters "^1.2.6"
 
 commonmark@^0.29.1:
   version "0.29.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,7 +554,7 @@ commonmark-react-renderer@^4.3.3:
 
 commonmark@^0.29.1:
   version "0.29.3"
-  resolved "https://repo.sonatype.com/repository/npm-all/commonmark/-/commonmark-0.29.3.tgz#bb1d5733bfe3ea213b412f33f16439cc12999c2c"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.29.3.tgz#bb1d5733bfe3ea213b412f33f16439cc12999c2c"
   integrity sha512-fvt/NdOFKaL2gyhltSy6BC4LxbbxbnPxBMl923ittqO/JBM0wQHaoYZliE4tp26cRxX/ZZtRsJlZzQrVdUkXAA==
   dependencies:
     entities "~2.0"
@@ -883,7 +883,7 @@ enhanced-resolve@^3.0.0:
 
 entities@~2.0:
   version "2.0.3"
-  resolved "https://repo.sonatype.com/repository/npm-all/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 errno@^0.1.3:
@@ -2047,7 +2047,7 @@ magic-string@^0.14.0:
 
 mdurl@~1.0.1:
   version "1.0.1"
-  resolved "https://repo.sonatype.com/repository/npm-all/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
@@ -2112,7 +2112,7 @@ minimist@0.0.8, minimist@~0.0.1:
 
 minimist@>=1.2.2:
   version "1.2.5"
-  resolved "https://repo.sonatype.com/repository/npm-all/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@^0.2.0:


### PR DESCRIPTION
https://issues.sonatype.org/browse/RSC-497

This PR merges the actual commonmark upgrade from my personal fork, where I originally implemented it, into the new Sonatype fork of react-commonmark